### PR TITLE
Restructured grid Sass.

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -9,7 +9,7 @@
 .grid-pad { padding: 20px 0 20px 20px; }
 
 /* line 17, ../sass/_grid.scss */
-[class*='col-'], .col { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; float: left; padding-right: 40px; }
+.col-1-8, .col-1-4, .col-1-3, .col-3-8, .col-1-2, .col-5-8, .col-2-3, .col-3-4, .col-7-8 { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; float: left; padding-right: 40px; }
 
 /* line 23, ../sass/_grid.scss */
 .col-1-8 { width: 12.5%; }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -14,18 +14,18 @@
   padding: $pad 0 $pad $pad;
 }
 
-[class*='col-'], .col {
+%col-base {
 	@include box-sizing(border-box);
 	float: left;
-	padding-right: $pad*2;
+	padding-right: $pad*2;	
 }
 
-.col-1-8 { width: 12.5%; }
-.col-1-4 { width: 25%; }
-.col-1-3 { width: 33.33%; }
-.col-3-8 { width: 37.5%; }
-.col-1-2 { width: 50%; }
-.col-5-8 { width: 62.5%; }
-.col-2-3 { width: 66.66%; }
-.col-3-4 { width: 75%; }
-.col-7-8 { width: 87.5%; }
+.col-1-8 { @extend %col-base; width: 12.5%; }
+.col-1-4 { @extend %col-base; width: 25%; }
+.col-1-3 { @extend %col-base; width: 33.33%; }
+.col-3-8 { @extend %col-base; width: 37.5%; }
+.col-1-2 { @extend %col-base; width: 50%; }
+.col-5-8 { @extend %col-base; width: 62.5%; }
+.col-2-3 { @extend %col-base; width: 66.66%; }
+.col-3-4 { @extend %col-base; width: 75%; }
+.col-7-8 { @extend %col-base; width: 87.5%; }


### PR DESCRIPTION
Changed grid Sass so we're being more specific about what classes get treated as columns. This is in reference to this bug: https://basecamp.com/2027151/projects/2023013-tribune-phase-2/todos/39916358-css-broke-on-add
