### PR TITLE
Update lift-search-form.php

### DIFF
--- a/wp/lift-search-form.php
+++ b/wp/lift-search-form.php
@@ -129,7 +129,7 @@ if ( !class_exists( 'Lift_Search_Form' ) ) {
 		}
 
 		public function loop() {
-			$path = dirname( __DIR__ ) . '/lift-search/templates/lift-loop.php';
+			$path = dirname( __DIR__ ) . '/templates/lift-loop.php';
 			include_once $path;
 		}
 


### PR DESCRIPTION
dirname(**DIR**) is returning the full plugin path, including the "/lift-search/" which caused files to not be found.  Removing "/lift-search/" anywhere you use this path structure will fix it.
