### PR TITLE
Moving init hook from 'plugins_loaded' to 'after_theme_setup' for WPCOM ...

### DIFF
--- a/lift-core.php
+++ b/lift-core.php
@@ -541,7 +541,7 @@ if ( !class_exists( 'Lift_Search' ) ) {
 
     }
 
-    add_action( 'plugins_loaded', array( 'Lift_Search', 'init' ) );
+    add_action( 'after_setup_theme', array( 'Lift_Search', 'init' ) );
 }
 
 


### PR DESCRIPTION
This change is coming out of WordPress VIP Request #22896.  Mo asked me to create the pull request.

I am in the process of working on an Amazon Cloud Search implementation for one of our clients. In the process, I discovered a problem with using the Lift Search plugin within the WordPress VIP environment. The plugin's 'init' method is currently hooked on the 'plugins_loaded' action. Because VIP plugins are loaded through the Theme APIs rather than the Plugins API, the current hook is too early. This is preventing the plugin from initializing.

This patch that corrects the problem by moving the plugin's init action to 'after_theme_setup'. Please let me know if you have any questions.
