### PR TITLE
Adds two new filter hooks for rendering additional input fields in the lift search form.

### DIFF
--- a/wp/lift-search-form.php
+++ b/wp/lift-search-form.php
@@ -122,7 +122,7 @@ if ( !class_exists( 'Lift_Search_Form' ) ) {
 
 			$html .= $this->form_filters();
 
-			$html = apply_filters( 'lift_form_add_fields', $html );
+			$html = apply_filters( 'lift_form_add_hidden_fields', $html );
 
 			$html .= "</ul></fieldset>";
 			$html .= "</div></form>";


### PR DESCRIPTION
Adds two new filter hooks, `lift_form_before_fields` and `lift_form_after_fields`. These hooks are intended to be used for rendering additional input fields in the lift search form.
