### PR TITLE
Fixing AWS API issue with new installs

### DIFF
--- a/api/cloud-config-api.php
+++ b/api/cloud-config-api.php
@@ -304,7 +304,7 @@ class Cloud_Config_Request {
 	const DATE_FORMAT_SIGV4 = 'Ymd\THis\Z';
 
 	private $endpoint = 'https://cloudsearch.us-east-1.amazonaws.com';
-	private $api_version = '2011-02-01';
+	private $api_version = '2013-01-01';
 	private $key;
 	private $secret_key;
 	private $region = false;

--- a/api/cloud-search-api.php
+++ b/api/cloud-search-api.php
@@ -6,7 +6,7 @@ class CloudSearch_API {
 	private $submission_uri;
 	private $search_uri;
 
-	const API_VERSION = '2011-02-01';
+	const API_VERSION = '2013-01-01';
 
 	/**
 	 *
@@ -19,7 +19,7 @@ class CloudSearch_API {
 	 * @param string $search_domain_uri
 	 * @param iLift_HTTP $http_interface
 	 */
-	public function __construct( $http_interface, $document_endpoint, $search_endpoint, $version = '2011-02-01' ) {
+	public function __construct( $http_interface, $document_endpoint, $search_endpoint, $version = '2013-01-01' ) {
 
 		$this->http_interface = $http_interface;
 

--- a/lift-core.php
+++ b/lift-core.php
@@ -371,7 +371,7 @@ class Lift_Search {
 	 */
 	public static function get_search_api() {
 		$lift_http = self::get_http_api();
-		return new CloudSearch_API( $lift_http, Lift_Search::get_document_endpoint(), Lift_Search::get_search_endpoint(), '2011-02-01' );
+		return new CloudSearch_API( $lift_http, Lift_Search::get_document_endpoint(), Lift_Search::get_search_endpoint(), '2013-01-01' );
 	}
 
 	public static function get_indexed_post_types() {


### PR DESCRIPTION
This allows people without an existing search domain to authenticate. AWS now forces the 2013 API on new search domains.
